### PR TITLE
Upgrade to tasty-mima 0.5.7.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 
 // Must stay in sync with TastyMiMaPlugin.TastyMiMaVersion
-val TastyMiMaVersion = "0.1.2"
+val TastyMiMaVersion = "0.1.3"
 
 inThisBuild(Def.settings(
   crossScalaVersions := Seq("2.12.17"),

--- a/sbt-tasty-mima/src/main/scala/sbttastymima/TastyMiMaPlugin.scala
+++ b/sbt-tasty-mima/src/main/scala/sbttastymima/TastyMiMaPlugin.scala
@@ -9,7 +9,7 @@ import sbt.plugins.JvmPlugin
 
 object TastyMiMaPlugin extends AutoPlugin {
   // Must stay in sync with TastyMiMaVersion in build.sbt
-  private val TastyMiMaVersion = "0.1.2"
+  private val TastyMiMaVersion = "0.1.3"
 
   object autoImport {
     val tastyMiMaPreviousArtifacts: SettingKey[Set[ModuleID]] =

--- a/sbt-tasty-mima/src/sbt-test/tastymima/basicok/build.sbt
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/basicok/build.sbt
@@ -1,6 +1,6 @@
 import tastymima.intf._
 
-scalaVersion := "3.1.0"
+scalaVersion := "3.2.2"
 name := "test-project"
 
 tastyMiMaPreviousArtifacts := Set(organization.value %% name.value % "0.0.1-SNAPSHOT")

--- a/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/build.sbt
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/build.sbt
@@ -1,7 +1,7 @@
 import tastymima.intf._
 
-crossScalaVersions := Seq("3.1.0", "2.13.10", "2.12.17")
-scalaVersion := "3.1.0"
+crossScalaVersions := Seq("3.2.2", "2.13.10", "2.12.17")
+scalaVersion := "3.2.2"
 name := "test-project"
 
 tastyMiMaPreviousArtifacts := Set(organization.value %% name.value % "0.0.1-SNAPSHOT")

--- a/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/test
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/test
@@ -6,7 +6,7 @@
 > set version := "0.0.2-SNAPSHOT"
 
 # filters are set in the build file, so tasty-mima check should pass
-> ++3.1.0
+> ++3.2.2
 > tastyMiMaReportIssues
 
 # Also test 2.x, because YOLO
@@ -17,7 +17,7 @@
 
 # remove all filters so tasty-mima check fails
 > set tastyMiMaConfig ~= { _.withReplacedProblemFilters(java.util.Arrays.asList()) }
-> ++3.1.0
+> ++3.2.2
 -> tastyMiMaReportIssues
 
 # Also test 2.x, because YOLO


### PR DESCRIPTION
This adds support for reading TASTy files generated by Scala 3.2.x.