### PR TITLE
Upgrade to tasty-mima 1.2.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 
 // Must stay in sync with TastyMiMaPlugin.TastyMiMaVersion
-val TastyMiMaVersion = "1.1.0"
+val TastyMiMaVersion = "1.2.0"
 
 inThisBuild(Def.settings(
   crossScalaVersions := Seq("2.12.17"),

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ inThisBuild(Def.settings(
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
 
-  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+  versionPolicyIntention := Compatibility.BinaryCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r),
 ))

--- a/sbt-tasty-mima/src/main/scala/sbttastymima/TastyMiMaPlugin.scala
+++ b/sbt-tasty-mima/src/main/scala/sbttastymima/TastyMiMaPlugin.scala
@@ -9,7 +9,7 @@ import sbt.plugins.JvmPlugin
 
 object TastyMiMaPlugin extends AutoPlugin {
   // Must stay in sync with TastyMiMaVersion in build.sbt
-  private val TastyMiMaVersion = "1.1.0"
+  private val TastyMiMaVersion = "1.2.0"
 
   object autoImport {
     val tastyMiMaPreviousArtifacts: SettingKey[Set[ModuleID]] =

--- a/sbt-tasty-mima/src/sbt-test/tastymima/basicok/build.sbt
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/basicok/build.sbt
@@ -1,6 +1,6 @@
 import tastymima.intf._
 
-scalaVersion := "3.3.0"
+scalaVersion := "3.4.0"
 name := "test-project"
 
 tastyMiMaPreviousArtifacts := Set(organization.value %% name.value % "0.0.1-SNAPSHOT")

--- a/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/build.sbt
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/build.sbt
@@ -1,7 +1,7 @@
 import tastymima.intf._
 
-crossScalaVersions := Seq("3.3.0", "3.2.2", "2.13.10", "2.12.17")
-scalaVersion := "3.3.0"
+crossScalaVersions := Seq("3.4.0", "3.3.0", "3.2.2", "2.13.10", "2.12.17")
+scalaVersion := "3.4.0"
 name := "test-project"
 
 tastyMiMaPreviousArtifacts := Set(organization.value %% name.value % "0.0.1-SNAPSHOT")

--- a/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/test
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/test
@@ -6,6 +6,8 @@
 > set version := "0.0.2-SNAPSHOT"
 
 # filters are set in the build file, so tasty-mima check should pass
+> ++3.4.0
+> tastyMiMaReportIssues
 > ++3.3.0
 > tastyMiMaReportIssues
 > ++3.2.2
@@ -19,6 +21,8 @@
 
 # remove all filters so tasty-mima check fails
 > set tastyMiMaConfig ~= { _.withReplacedProblemFilters(java.util.Arrays.asList()) }
+> ++3.4.0
+-> tastyMiMaReportIssues
 > ++3.3.0
 -> tastyMiMaReportIssues
 > ++3.2.2

--- a/sbt-tasty-mima/src/sbt-test/tastymima/version-override/build.sbt
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/version-override/build.sbt
@@ -1,10 +1,10 @@
 import tastymima.intf._
 
-scalaVersion := "3.3.0"
+scalaVersion := "3.4.0"
 name := "test-project"
 
-tastyMiMaVersionOverride := Some("0.3.0")
-tastyMiMaTastyQueryVersionOverride := Some("0.8.1")
+tastyMiMaVersionOverride := Some("1.1.0")
+tastyMiMaTastyQueryVersionOverride := Some("1.3.0")
 
 tastyMiMaPreviousArtifacts := Set(organization.value %% name.value % "0.0.1-SNAPSHOT")
 


### PR DESCRIPTION
This brings support for Scala 3.4.x by default.