### PR TITLE
Upgrade to sbt 1.11.3 and sbt-ci-release 1.11.0.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.11.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.4")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.5.10")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.11.0")
 addSbtPlugin("ch.epfl.scala"  % "sbt-version-policy" % "2.1.0")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-tasty-mima" % "1.3.0")


### PR DESCRIPTION
This is necessary to publish to the new Maven Central Portal.