### PR TITLE
Cross-build for sbt 2.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
       - uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
-      - name: Set up JDK 8
+      - name: Set up JDK 17
         uses: coursier/setup-action@v1
         with:
-          jvm: temurin:1.8
+          jvm: temurin:17
           apps: sbt
       - name: sbt ci-release
         run: sbt versionCheck ci-release

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '17', '21' ]
 
     runs-on: ubuntu-latest
 

--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,17 @@ lazy val `sbt-tasty-mima` = project.in(file("sbt-tasty-mima"))
         case _      => "2.0.0"
       }
     },
+    Compile / doc /skip := {
+      // Suppress Scaladoc publishing due to a bug
+      // undefined: new dataclass.data # -1: TermRef(TypeRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object dataclass),data),<init>) at readTasty
+      scalaVersion.value == sbt2ScalaVersion
+    },
+    scalacOptions += {
+      scalaBinaryVersion.value match {
+      case "2.12" => "-release:8"
+      case _      => "-release:17"
+    }
+  },
 
     strictCompileSettings,
     addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0"),

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,11 @@
 // Must stay in sync with TastyMiMaPlugin.TastyMiMaVersion
 val TastyMiMaVersion = "1.4.0"
 
+val sbt1ScalaVersion = "2.12.20"
+val sbt2ScalaVersion = "3.8.4"
+
 inThisBuild(Def.settings(
-  crossScalaVersions := Seq("2.12.17"),
+  crossScalaVersions := Seq(sbt1ScalaVersion, sbt2ScalaVersion),
   scalaVersion := crossScalaVersions.value.head,
 
   scalacOptions ++= Seq(
@@ -33,11 +36,15 @@ inThisBuild(Def.settings(
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r),
 ))
 
-val strictCompileSettings = Seq(
-  scalacOptions ++= Seq(
-    "-Xfatal-warnings",
-  ),
-)
+val strictCompileSettings = Seq(scalacOptions ++= {
+  if (scalaVersion.value.startsWith("3."))
+    Seq(
+      "-Werror",
+      "-Wconf:msg=`_` is deprecated:s",
+      "-Wconf:msg=object JavaConverters in package scala.collection is deprecated:s",
+    )
+  else Seq("-Xfatal-warnings")
+})
 
 lazy val root = project.in(file("."))
   .aggregate(`sbt-tasty-mima`).settings(
@@ -48,8 +55,17 @@ lazy val `sbt-tasty-mima` = project.in(file("sbt-tasty-mima"))
   .enablePlugins(SbtPlugin)
   .settings(
     name := "sbt-tasty-mima",
+    crossScalaVersions := Seq(sbt1ScalaVersion, sbt2ScalaVersion),
+    scalaVersion := sbt1ScalaVersion,
+    (pluginCrossBuild / sbtVersion) := {
+      scalaBinaryVersion.value match {
+        case "2.12" => "1.11.3"
+        case _      => "2.0.0"
+      }
+    },
 
     strictCompileSettings,
+    addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0"),
     libraryDependencies += "ch.epfl.scala" % "tasty-mima-interface" % TastyMiMaVersion,
 
     // Skip `versionCheck` for snapshot releases
@@ -78,6 +94,7 @@ lazy val `sbt-tasty-mima` = project.in(file("sbt-tasty-mima"))
     },
 
     scriptedBufferLog := false,
+    scriptedSbt := sys.props.getOrElse("scripted.sbt.version", (pluginCrossBuild / sbtVersion).value),
     scriptedLaunchOpts := {
       scriptedLaunchOpts.value ++
         Seq("-Xmx1024M", "-Dplugin.version=" + version.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.3
+sbt.version=1.12.12

--- a/sbt-tasty-mima/src/main/scala/sbttastymima/TastyMiMaPlugin.scala
+++ b/sbt-tasty-mima/src/main/scala/sbttastymima/TastyMiMaPlugin.scala
@@ -6,6 +6,7 @@ import sbt.{CrossVersion, _}
 import sbt.Keys._
 import sbt.librarymanagement._
 import sbt.plugins.JvmPlugin
+import sbtcompat.PluginCompat._
 
 object TastyMiMaPlugin extends AutoPlugin {
   // Must stay in sync with TastyMiMaVersion in build.sbt
@@ -49,8 +50,8 @@ object TastyMiMaPlugin extends AutoPlugin {
   override def globalSettings: Seq[Setting[_]] = Def.settings(
     tastyMiMaVersionOverride := None,
     tastyMiMaTastyQueryVersionOverride := None,
-    tastyMiMaConfig := new tastymima.intf.Config(),
-    tastyMiMaJavaBootClasspath := {
+    tastyMiMaConfig := Def.uncached(new tastymima.intf.Config()),
+    tastyMiMaJavaBootClasspath := Def.uncached {
       System.getProperty("sun.boot.class.path") match {
         case null =>
           Seq(FileSystems.getFileSystem(java.net.URI.create("jrt:/")).getPath("modules", "java.base"))
@@ -75,7 +76,8 @@ object TastyMiMaPlugin extends AutoPlugin {
       val config = csrConfiguration.value.withAutoScalaLibrary(false)
       lmcoursier.CoursierDependencyResolution(config)
     },
-    tastyMiMaClasspath := {
+    tastyMiMaClasspath := Def.uncached {
+      implicit val conv: xsbti.FileConverter = fileConverter.value
       val s = streams.value
       val log = s.log
       val lm = (tastyMiMaClasspath / dependencyResolution).value
@@ -101,11 +103,11 @@ object TastyMiMaPlugin extends AutoPlugin {
         case Left(unresolvedWarning) =>
           throw unresolvedWarning.resolveException
         case Right(cp) =>
-          Attributed.blankSeq(cp)
+          toAttributedFiles(cp)
       }
     },
     tastyMiMaPreviousClasspaths / dependencyResolution := dependencyResolution.value,
-    tastyMiMaPreviousClasspaths := {
+    tastyMiMaPreviousClasspaths := Def.uncached {
       val s = streams.value
       val log = s.log
       val lm = (tastyMiMaPreviousClasspaths / dependencyResolution).value
@@ -156,11 +158,12 @@ object TastyMiMaPlugin extends AutoPlugin {
         }
       }
     },
-    tastyMiMaCurrentClasspath := {
+    tastyMiMaCurrentClasspath := Def.uncached {
+      implicit val conv: xsbti.FileConverter = fileConverter.value
       val javaBootCp = tastyMiMaJavaBootClasspath.value
       val classDir = (Compile / classDirectory).value.toPath()
-      val jar = (Compile / packageBin / artifactPath).value.toPath()
-      val cp0 = Attributed.data((Compile / fullClasspath).value).map(_.toPath())
+      val jar = artifactPathToFile((Compile / packageBin / artifactPath).value).toPath()
+      val cp0 = toNioPaths((Compile / fullClasspath).value)
 
       val cp: Seq[Path] = javaBootCp ++ cp0
       val entry: Path = cp0.find { path =>
@@ -171,11 +174,12 @@ object TastyMiMaPlugin extends AutoPlugin {
 
       (cp, entry)
     },
-    tastyMiMaReportIssues := {
+    tastyMiMaReportIssues := Def.uncached {
+      implicit val conv: xsbti.FileConverter = fileConverter.value
       val projectID = moduleName.value
       val log = streams.value.log
 
-      val tastyMiMaCp = Attributed.data(tastyMiMaClasspath.value).map(_.toURI().toURL()).toArray
+      val tastyMiMaCp = toNioPaths(tastyMiMaClasspath.value).map(_.toUri.toURL).toArray
       val config = tastyMiMaConfig.value
       val tastyMiMa = tastymima.intf.TastyMiMa.newInstance(tastyMiMaCp, getClass().getClassLoader(), config)
 

--- a/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/build.sbt
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/build.sbt
@@ -1,6 +1,6 @@
 import tastymima.intf._
 
-crossScalaVersions := Seq("3.7.1", "3.5.0", "3.4.0", "3.3.0", "3.2.2", "2.13.10", "2.12.17")
+crossScalaVersions := Seq("3.7.1", "3.5.0", "3.4.0", "3.3.0", "3.2.2", "2.13.18", "2.12.21")
 scalaVersion := "3.7.1"
 name := "test-project"
 

--- a/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/test
+++ b/sbt-tasty-mima/src/sbt-test/tastymima/crossversion/test
@@ -18,9 +18,9 @@
 > tastyMiMaReportIssues
 
 # Also test 2.x, because YOLO
-> ++2.13.10
+> ++2.13.18
 > tastyMiMaReportIssues
-> ++2.12.17
+> ++2.12.21
 > tastyMiMaReportIssues
 
 # remove all filters so tasty-mima check fails
@@ -37,7 +37,7 @@
 -> tastyMiMaReportIssues
 
 # Also test 2.x, because YOLO
-> ++2.13.10
+> ++2.13.18
 -> tastyMiMaReportIssues
-> ++2.12.17
+> ++2.12.21
 -> tastyMiMaReportIssues


### PR DESCRIPTION
- Cross-build for sbt 2.x 
- Update sbt version to latest 1.12.12 
- Update GH Actions runners to use JDK 17 
- Set explciit JDK target version to 8 (sbt 1.x) and 17 (sbt 2.x)